### PR TITLE
CI test failure fix and addition of pull requests to CI triggers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/dyno/language.py
+++ b/dyno/language.py
@@ -14,6 +14,7 @@ class NotPositiveSemidefinite(np.linalg.LinAlgError):
 
     pass
 
+
 @language_element
 def _Matrix(*lines):
     mat = np.array(lines, np.float64)
@@ -26,7 +27,6 @@ def _Vector(*elements):
     mat = np.array(elements, np.float64)
     assert mat.ndim == 1
     return mat
-
 
 
 @language_element
@@ -56,7 +56,6 @@ class Normal:
 
     Μ: Vector  # this is capital case μ, not M... 😭
     Σ: Matrix
-
 
     signature = {"Σ": "_Matrix", "Μ": "Optional[_Vector]"}
 

--- a/dyno/language.py
+++ b/dyno/language.py
@@ -14,6 +14,20 @@ class NotPositiveSemidefinite(np.linalg.LinAlgError):
 
     pass
 
+@language_element
+def _Matrix(*lines):
+    mat = np.array(lines, np.float64)
+    assert mat.ndim == 2
+    return mat
+
+
+@language_element
+def _Vector(*elements):
+    mat = np.array(elements, np.float64)
+    assert mat.ndim == 1
+    return mat
+
+
 
 @language_element
 class Normal:
@@ -43,10 +57,13 @@ class Normal:
     Μ: Vector  # this is capital case μ, not M... 😭
     Σ: Matrix
 
+
+    signature = {"Σ": "_Matrix", "Μ": "Optional[_Vector]"}
+
     @greek_tolerance
     def __init__(self, Σ, Μ=None):
 
-        Sigma = Σ
+        Sigma = np.array(Σ)
         mu = Μ
 
         self.Σ = np.atleast_2d(np.array(Sigma, dtype=float))

--- a/dyno/model.py
+++ b/dyno/model.py
@@ -8,7 +8,8 @@ from .misc import jacobian
 
 from abc import ABC, abstractmethod
 
-from typing import Callable, Self, overload, Literal
+from typing import Callable, overload, Literal
+from typing_extensions import Self
 from .types import Vector, Matrix, IRFType, Solver, SymbolType, DynamicFunction
 from pandas import DataFrame
 from .language import Normal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dolang = "^0.0.21"
 numpy = "^2.0.0"
 scipy = "^1.12.0"
 pandas = "^2.2.2"
+typing_extensions = "^4.12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.0.0"
@@ -25,7 +26,7 @@ black = "^24.10.0"
 mkdocs = "^1.6.1"
 mkapi = "^4.0.1"
 coverage = "^6.4.4"
-pytest-cov = "^3.0.0"
+pytest-cov = "^4.0.0"
 pymdown-extensions = "^10.12"
 python-markdown-math = "^0.8"
 


### PR DESCRIPTION
It turns out that the main problem was that I unknowingly deleted code from `language.py` that was used by `dolang` but seemed useless in the source code. I have rolled back these changes, and I am trying to figure out how to deal with the redefinitions of the Vector and Matrix types in `language.py`. As a temporary solution to prevent Mypy from complaining, I have added an underscore to distinguish them from the types I defined.

Otherwise, I modified the dependencies and added `pull_request` to the CI triggers so that a CI check is launched on each opened, reopened or synchronized pull request, so everything should work fine now :crossed_fingers: .