### PR TITLE
Python 3.12 and 3.13 CI + removal of plotlyjs from html representation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["py310", "py311"] # "py312" ] # requires dolang to move dependencies up
+        python-version: ["py310", "py311", "py312", "py313" ]
 
     name: Dyno Python Version ${{ matrix.python-version }}
     steps:

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ version = "0.1.5.dev6"
 dyno = { path = "." }
 
 [package.run-dependencies]
-dynare-preprocessor-pylib = { version = "==0.0.0.dev1", build = "py311hcc915ae_2" }
+dynare-preprocessor-pylib = "==0.0.0.dev1"
 dolang = ">=0.0.20"
 numpy = ">=2.0.0, <2.3.0" # Compatibility with notebook.link scipy
 scipy = ">=1.12.0"
@@ -27,7 +27,7 @@ backend = { name = "pixi-build-python", version = "==0.3.2" }
 
 [package.host-dependencies] 
 hatchling = "==1.26.3"
-python = "<3.13,>=3.10"
+python = "<3.14,>=3.11"
 
 [feature.test.dependencies]
 pytest = ">=8.3.3"
@@ -87,9 +87,17 @@ python = "3.10.*"
 [feature.py311.dependencies]
 python = "3.11.*"
 
+[feature.py312.dependencies]
+python = "3.12.*"
+
+[feature.py313.dependencies]
+python = "3.13.*"
+
 [environments]
 prod = ["gui", "jupyter"]
 test = ["test", "gui", "jupyter"]
 dev = ["test", "gui", "lint", "jupyter", "docs"]
 py310 = ["test", "lint", "py310"]
 py311 = ["test", "lint", "py311"]
+py312 = ["test", "lint", "py312"]
+py313 = ["test", "lint", "py313"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,6 @@ scipy = ">=1.12.0"
 pandas = ">=2.2.2"
 typing_extensions = ">=4.12.0"
 plotly = ">=5.18.0"
-python-kaleido = ">=1.0.0,<2"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "==0.3.2" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,19 +7,20 @@ platforms = ["linux-64"]
 
 [package]
 name = "dyno"
-version = "0.1.5.dev3"
+version = "0.1.5.dev6"
 
 [dependencies]
 dyno = { path = "." }
 
 [package.run-dependencies]
-dynare-preprocessor-pylib = "0.0.0.dev1.*"
+dynare-preprocessor-pylib = { version = "==0.0.0.dev1", build = "py311hcc915ae_2" }
 dolang = ">=0.0.20"
-numpy = ">=2.0.0"
+numpy = ">=2.0.0, <2.3.0" # Compatibility with notebook.link scipy
 scipy = ">=1.12.0"
 pandas = ">=2.2.2"
 typing_extensions = ">=4.12.0"
 plotly = ">=5.18.0"
+python-kaleido = ">=1.0.0,<2"
 
 [package.build]
 backend = { name = "pixi-build-python", version = "==0.3.2" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ backend = { name = "pixi-build-python", version = "==0.3.2" }
 
 [package.host-dependencies] 
 hatchling = "==1.26.3"
-python = "<3.14,>=3.11"
+python = "<3.14,>=3.10"
 
 [feature.test.dependencies]
 pytest = ">=8.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dyno"
 version = "0.1.5"
-requires-python = ">= 3.10,<3.13"
+requires-python = ">= 3.10,<3.14"
 
 [build-system]
 build-backend = "hatchling.build"

--- a/src/dyno/model.py
+++ b/src/dyno/model.py
@@ -105,7 +105,7 @@ class RecursiveSolution:
         fig.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
         fig.update_yaxes(title_text="", matches=None)
         fig.update_xaxes(title_text="")
-        
+
         html = f"""
         <h3>Eigenvalues</h3>
         {evv.to_html()}
@@ -121,6 +121,7 @@ class RecursiveSolution:
         {fig.to_html(full_html=False, include_plotlyjs=False)}
         """
         return html
+
 
 class Model(ABC):
     """Abstract class representing an economic model"""

--- a/src/dyno/model.py
+++ b/src/dyno/model.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 from .typedefs import TVector, TMatrix, IRFType, Solver, DynamicFunction
 import pandas as pd
 from .language import Exogenous, Normal, Deterministic, ProductNormal
+
 import plotly.express as px
 
 
@@ -100,10 +101,11 @@ class RecursiveSolution:
             facet_col="variable",
             facet_col_wrap=2,
         )
+
         fig.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
         fig.update_yaxes(title_text="", matches=None)
         fig.update_xaxes(title_text="")
-
+        
         html = f"""
         <h3>Eigenvalues</h3>
         {evv.to_html()}
@@ -116,10 +118,9 @@ class RecursiveSolution:
         <h3>Conditional moments</h3>
         {df_cmoments.to_html()}
         <h3>IRFs</h3>
-        {fig.to_html(full_html=False, include_plotlyjs=True)}
+        {fig.to_html(full_html=False, include_plotlyjs=False)}
         """
         return html
-
 
 class Model(ABC):
     """Abstract class representing an economic model"""


### PR DESCRIPTION
The removal of plotlyjs is a temporary solution to avoid slowing down the new `jupyter-dsge` extension. It should be eventually replaced with a proper Report class or `dsge_report` function that takes a parameter `include_plotlyjs` set by default to True.