### PR TITLE
Parse annotation entries in the grammar

### DIFF
--- a/src/dyno/dynspec/analyze.py
+++ b/src/dyno/dynspec/analyze.py
@@ -328,6 +328,9 @@ class AssignmentEvaluator(FormulaEvaluator):
             return str(parsed)
         return stripped
 
+    # NOTE: no longer called for parsed brackets. Remaining references:
+    # the unused function below, and an unreachable branch of
+    # _parse_inline_content (META_TEXT never begins with "[").
     def _parse_canonical_metadata_token(self, token_value: str) -> Dict[str, Any]:
         stripped = token_value.strip()
         if not (stripped.startswith("[") and stripped.endswith("]")):
@@ -365,6 +368,10 @@ class AssignmentEvaluator(FormulaEvaluator):
 
         return self._normalize_metadata(normalized_items)
 
+    # NOTE: unused; nothing in the package calls it. If called, it would
+    # read a quoted string after :: as a tag, whereas
+    # _parse_inline_content reads it as a label. Kept to keep this
+    # change minimal; removable separately.
     def _parse_inline_metadata_token(self, token_value: str) -> Dict[str, Any]:
         stripped = token_value.strip()
 
@@ -408,22 +415,56 @@ class AssignmentEvaluator(FormulaEvaluator):
 
         return self._normalize_metadata(normalized_items)
 
-    def statement_metadata(self, tree):
-        """Unified handler for statement_metadata nodes.
+    def _annotation_to_metadata(self, ann_tree) -> "Dict[str, Any]":
+        """Convert a parsed annotation node to a metadata dict.
 
-        The grammar now makes :: an explicit (filtered) terminal, so the token
-        value is always just the *content* — never prefixed with ::.
-
-        Three token types arrive here:
-          METADATA_BODY  — content that followed :: (free text or [bracket])
-          INLINE_BRACKET — space-prefixed [tag, key=val] (no ::)
-          BLOCK_TAG      — [tag, key=val] without leading space (block prefix)
+        The grammar has already separated the entries (kv, baretag,
+        strtag), so no string splitting is needed. The dictionaries
+        are unchanged: a quoted string in bracket position is a tag,
+        and kv values receive the same YAML coercion as before.
         """
-        raw = str(tree.children[0]).strip()
-        if raw.startswith("["):
-            return self._parse_canonical_metadata_token(raw)
-        # Bare text that came after :: — treat as tag(s) / kv pairs
-        return self._parse_inline_content(raw)
+        normalized_items: "List[tuple[str, Any]]" = []
+        for entry in ann_tree.children:
+            if entry is None:
+                continue
+            if entry.data == "kv":
+                key = str(entry.children[0].children[0])
+                valnode = entry.children[1]
+                if isinstance(valnode, Tree):  # cname -> name
+                    value_text = str(valnode.children[0])
+                else:  # NUMBER or quoted-string token
+                    value_text = str(valnode)
+                normalized_items.append(
+                    ("kv", (key, self._coerce_metadata_value(value_text)))
+                )
+            elif entry.data == "baretag":
+                normalized_items.append(
+                    ("tag", str(entry.children[0].children[0]))
+                )
+            else:  # strtag: a quoted string in a bracket is a tag
+                value = self._coerce_metadata_value(str(entry.children[0]))
+                if not isinstance(value, str):
+                    raise DefinitionError(
+                        f"Invalid metadata tag: {entry.children[0]}"
+                    )
+                normalized_items.append(("tag", value))
+        if not normalized_items:
+            return {"tags": []}
+        return self._normalize_metadata(normalized_items)
+
+    def statement_metadata(self, tree):
+        """Handler for statement_metadata nodes.
+
+        The node's single child is either an annotation subtree (a
+        parsed [entries] bracket, after :: or inline) or a META_TEXT
+        token (free text after ::; a bracket never produces this
+        token).
+        """
+        child = tree.children[0]
+        if isinstance(child, Tree):
+            return self._annotation_to_metadata(child)
+        # Bare text that came after :: — treat as tag(s) / quoted label
+        return self._parse_inline_content(str(child).strip())
 
     def _parse_inline_content(self, content: str) -> "Dict[str, Any]":
         """Parse the text content that appears after :: (no :: prefix expected)."""
@@ -569,9 +610,8 @@ class AssignmentEvaluator(FormulaEvaluator):
         return None
 
     def block_tag(self, tree):
-        """Handle block_tag nodes — always a BLOCK_TAG bracketed token."""
-        raw = str(tree.children[0]).strip()
-        return self._parse_canonical_metadata_token(raw)
+        """Handler for block_tag nodes: a parsed annotation bracket."""
+        return self._annotation_to_metadata(tree.children[0])
 
     def annotated_block(self, tree):
         block_meta = self.visit(tree.children[0])  # block_tag node

--- a/src/dyno/dynspec/grammars/grammar.lark
+++ b/src/dyno/dynspec/grammars/grammar.lark
@@ -45,34 +45,40 @@ quantified_assignment: _FORALL "t" ["," t_double_bound] ":" variable _ASSIGN for
 
 # ── Metadata annotation ───────────────────────────────────────────────────────
 #
-# Statement annotation (same line as the statement):
-#   :: <content>        content is a quoted string, bare identifier, or [key=val]
-#   [key=val, tag]      bracket notation (no :: required)
+# One bracket grammar in every position; an entry is a bare tag, a
+# quoted tag, or key=value.
 #
-# Block annotation (precedes a { block }):
-#   [tag] { … }         bracket tag (no ::)
-#   [tag] :: { … }      bracket tag with explicit :: separator
-#
-# Note: :: [tag] { } is NOT valid — :: only follows a statement or a block tag.
+# Statement forms:  :: [entries]  |  :: free text  |  [entries] inline
+# Block forms:      [entries] { … }  |  [entries] :: { … }
+# (:: [entries] { … } is not valid: :: never precedes a block tag.)
 
-# Inline statement annotation — :: or bracket on the same line as a statement
-statement_metadata: _COLONCOLON METADATA_BODY   // :: <text or [...]>
-                  | INLINE_BRACKET              // [tag] inline (space-prefixed)
+statement_metadata: _COLONCOLON_LB annotation "]"   // :: [entries]
+                  | _COLONCOLON META_TEXT           // :: free text
+                  | _INLINE_LB annotation "]"       // [entries] inline
 
-# Block tag — bracket notation for annotated_block prefix (no leading space)
-block_tag: BLOCK_TAG
+# Block tag: the bracket prefixing an annotated_block (no leading space)
+block_tag: _SOL_LB annotation "]"
 
-# :: separator (filtered — not included in the tree)
+# Bracket interior: comma-separated entries
+annotation: (entry ("," entry)*)?
+?entry: kv | strtag | baretag
+kv: cname "=" kval
+?kval: cname | NUMBER | ASTRING
+baretag: cname
+strtag: ASTRING
+
+# :: separator (filtered out of the tree)
 _COLONCOLON: /[ \t]*::/
 
-# Content after ::  —  either a bracketed list or free text (no newline/comment/brace)
-METADATA_BODY.3: /[ \t]*(?:\[[^\]\r\n]*\]|[^\r\n#{][^\r\n#]*)/
+# The three anchors, unchanged; each match now ends at the opening [
+_SOL_LB.3: /^[ \t]*\[/m
+_INLINE_LB.3: /[ \t]+\[/
+_COLONCOLON_LB.4: /[ \t]*::[ \t]*\[/
 
-# Inline bracket annotation:  <whitespace>[tag, key=val]
-INLINE_BRACKET.3: /[ \t]+\[[^\]\r\n]*\]/
+# Free text after :: (never begins with [)
+META_TEXT.3: /[ \t]*[^\r\n#{\[][^\r\n#]*/
 
-# Block tag prefix:  [tag, key=val]  at the start of a line (no expression before it)
-BLOCK_TAG.3: /^[ \t]*\[[^\]\r\n]*\]/m
+ASTRING: /"[^"\r\n]*"|'[^'\r\n]*'/
 
 
 _FORALL.1: ("∀" | "forall")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from dyno import DynoModel
@@ -240,3 +242,97 @@ y[t] = 1 [production
 """
     with pytest.raises(ParserError):
         DynoFile(txt)
+
+
+def test_empty_metadata_bracket_yields_no_metadata():
+    txt = """
+alpha := 0.3
+k[~] := 1
+y[t] = alpha * k[t-1] []
+"""
+
+    symbolic = DynoFile(txt)
+
+    assert symbolic.equations[0].meta.statement_metadata == {}
+
+
+def test_metadata_entries_mix_in_any_order():
+    txt = """
+alpha := 0.3
+k[~] := 1
+y[t] = alpha * k[t-1] [a, id=res, "note", k=2, v="x y", b]
+"""
+
+    symbolic = DynoFile(txt)
+
+    eq_meta = symbolic.equations[0].meta.statement_metadata
+    assert eq_meta["tags"] == ["a", "note", "b"]
+    assert eq_meta["id"] == "res"
+    assert eq_meta["k"] == 2
+    assert eq_meta["v"] == "x y"
+
+
+def test_junk_bracket_interior_is_rejected():
+    txt = """
+y[t] = 1 [a + b]
+"""
+    with pytest.raises(ParserError):
+        DynoFile(txt)
+
+
+def test_junk_block_bracket_is_rejected():
+    txt = """
+[the transition block] {
+    y[t] = 1
+}
+"""
+    with pytest.raises(ParserError):
+        DynoFile(txt)
+
+
+def test_negative_metadata_value_is_rejected():
+    txt = """
+y[t] = 1 [k=-2]
+"""
+    with pytest.raises(ParserError):
+        DynoFile(txt)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["neo.dyno", "rbc.dyno", "ramst.dyno", "neoclassical_ramsey.dyno"],
+)
+def test_examples_still_parse(name):
+    path = Path(__file__).parent.parent / "examples" / name
+    DynoFile(path.read_text())
+
+
+def test_file_with_every_annotation_position():
+    txt = """
+@name: Demo
+
+alpha <- 0.3
+
+[block_a, id=g1, note="transition"] {
+    k[t] = (1-delta)*k[t-1] + i[t]   :: [id=lom, capital]
+    y[t] = k[t-1]^alpha              :: "production"
+}
+
+c[t] = y[t] - i[t] [budget, id=res]
+"""
+
+    symbolic = DynoFile(txt)
+
+    metas = [eq.meta.statement_metadata for eq in symbolic.equations]
+    assert metas[0] == {
+        "tags": ["block_a", "capital"],
+        "id": "lom",
+        "note": "transition",
+    }
+    assert metas[1] == {
+        "tags": ["block_a"],
+        "id": "g1",
+        "note": "transition",
+        "label": "production",
+    }
+    assert metas[2] == {"tags": ["budget"], "id": "res"}


### PR DESCRIPTION
## Summary

Annotation brackets are currently treated as raw tokens and then split in
`analyze.py`. This PR moves the bracket contents into the Lark grammar.

The parse tree now represents each annotation entry explicitly as:

- `kv`: `key=value`
- `baretag`: `tag`
- `strtag`: `"tag"`

For documented annotation forms, the resulting metadata dictionaries are
unchanged.

## Why

This makes the annotation syntax explicit and removes the need for
downstream Python code to re-split raw bracket text. It also provides a
single extension point: an importing grammar can add another entry form
with `%extend entry`.

For example, the grammar can now distinguish directly between:

```text
[id=res]       → kv(id, res)
[capital]      → baretag(capital)
["transition"] → strtag("transition")
```

Previously, each bracket was represented as one raw string, and these
distinctions had to be reconstructed in Python.

## Implementation

The bracket contents are parsed by the following rules:

```lark
annotation: (entry ("," entry)*)?
?entry: kv | strtag | baretag
kv: cname "=" kval
?kval: cname | NUMBER | ASTRING
baretag: cname
strtag: ASTRING
```

The existing positional anchors are unchanged:

* `[` at the start of a line;
* `[` preceded by whitespace; and
* `[` following `::`.

These anchors continue to distinguish annotation brackets from indexing.
Free text following `::` remains a token and is read by the existing
code, unchanged.

In `analyze.py`, `statement_metadata` and `block_tag` now pass parsed
annotation nodes to `_annotation_to_metadata`. *The legacy token splitters
in `analyze.py` are untouched for now.*

## Examples 

For example:

```text
[id=res, tag]
→ annotation(kv(id, res), baretag(tag))
```

Current tree structure:

```text
statement_metadata
  " [id=res, tag]"
```

New tree structure:

```text
statement_metadata
  annotation
    kv
      name  id
      name  res
    baretag
      name  tag
```

The same rules apply in each annotation position:

```dyno
[block_a, id=g1] {
    k[t] = (1-delta)*k[t-1] + i[t] :: [id=lom, capital]
}

c[t] = y[t] - i[t] [budget, id=res]
```

Here the grammar identifies:

```text
[block_a, id=g1]
→ baretag(block_a) · kv(id, g1)

[id=lom, capital]
→ kv(id, lom) · baretag(capital)

[budget, id=res]
→ baretag(budget) · kv(id, res)
```

Different entry kinds can also be freely mixed:

```text
[a, id=res, "note", k=2, b, v="x y"]
→ baretag(a)
  · kv(id, res)
  · strtag("note")
  · kv(k, 2)
  · baretag(b)
  · kv(v, "x y")
```

## Compatibility

* Files without annotations retain the same parse tree.

* Documented annotation forms produce the same metadata dictionaries.

* Inline, block-level, and `:: [...]` annotations all use the same
  `annotation` and `entry` rules.

* Empty brackets remain valid:

  ```dyno
  x[t] = 1 []
  ```

* Invalid interiors such as `[a + b]` and `[two words]` were already
  rejected by the Python reader; they now fail earlier, in the parser.

* The explicit grammar is narrower than the old Python splitter for some
  undocumented forms. Identifiers must match `NAME`, values must match
  `cname`, `NUMBER`, or `ASTRING`, and every comma must separate two
  entries. Forms such as the following are therefore rejected:

  ```text
  [k=-2]          # negative value
  [a,]            # trailing comma
  [_tag]          # identifier outside NAME
  [k=two words]   # unquoted multi-word value
  ```

  A negative value can still be represented as text:

  ```text
  [k="-2"]
  ```

* Labels and quoted tags remain distinct:

  ```text
  x[t] = 1 :: "Labor Supply"   → label
  x[t] = 1 :: ["Labor Supply"] → quoted annotation tag
  ```

No new annotation form is introduced by this PR.

## Tests

The existing sixteen metadata tests pass unchanged. Seven tests are added
for:

* empty brackets;
* mixed entry kinds and ordering;
* quoted and numeric values;
* rejection of invalid interiors;
* rejection of negative values;
* all four shipped example models; and
* a model exercising every annotation position.

The final test parses the following complete example:

```dyno
@name: Demo

alpha <- 0.3

[block_a, id=g1, note="transition"] {
    k[t] = (1-delta)*k[t-1] + i[t] :: [id=lom, capital]
    y[t] = k[t-1]^alpha            :: "production"
}

c[t] = y[t] - i[t] [budget, id=res]
```

This covers:

* a block-prefix annotation;
* an annotation following `::`;
* a free-text label following `::`; and
* an inline annotation following a statement.

## Validation

* `pixi run test` (`pytest --ignore=tests/dynare`): 80 passed; the 15
  failures are identical to `main` in the same environment and none
  involve metadata. `tests/test_metadata.py` passes 26/26.
* `pixi run typecheck` (`mypy src --ignore-missing-imports`): 37
  pre-existing errors in 8 files, identical to `main`; none introduced
  by this PR.